### PR TITLE
Atomize rule

### DIFF
--- a/lib/validate.ex
+++ b/lib/validate.ex
@@ -4,7 +4,7 @@ defmodule Validate do
   """
   alias Validate.Validator.{Error, Arg}
 
-  @fns ~w[between cast characters date_string digits_between digits ends_with in ip lowercase max_digits max min_digits min not_ends_with not_in not_regex not_starts_with nullable regex required size starts_with type uppercase url uuid]
+  @fns ~w[between cast characters date_string digits_between digits ends_with in ip lowercase max_digits max min_digits min not_ends_with not_in not_regex not_starts_with nullable regex required size starts_with type uppercase url uuid atomize]
 
   @doc """
   Validates an input against a given list of rules
@@ -129,7 +129,7 @@ defmodule Validate do
   defp run_validator_rule(opts) do
     handler = get_handler(opts)
 
-    result = handler.(%Arg{value: opts.value, arg: opts.arg, input: opts.input})
+    result = handler.(%Arg{value: opts.value, arg: opts.arg, input: opts.input, rules: opts.rules})
 
     path = if opts.valueName != nil, do: [opts.valueName], else: []
     path = opts.path ++ path

--- a/lib/validate.ex
+++ b/lib/validate.ex
@@ -129,7 +129,8 @@ defmodule Validate do
   defp run_validator_rule(opts) do
     handler = get_handler(opts)
 
-    result = handler.(%Arg{value: opts.value, arg: opts.arg, input: opts.input, rules: opts.rules})
+    result =
+      handler.(%Arg{value: opts.value, arg: opts.arg, input: opts.input, rules: opts.rules})
 
     path = if opts.valueName != nil, do: [opts.valueName], else: []
     path = opts.path ++ path

--- a/lib/validate/rules/atomize.ex
+++ b/lib/validate/rules/atomize.ex
@@ -4,13 +4,15 @@ defmodule Validate.Rules.Atomize do
   import Validate.Validator
 
   def validate(%{value: value, rules: rules}) do
-      value = Enum.reduce(rules[:map], value, fn {key, _}, value ->
+    value =
+      Enum.reduce(rules[:map], value, fn {key, _}, value ->
         if is_atom(key) do
           skey = Atom.to_string(key)
+
           if !Map.has_key?(value, key) && Map.has_key?(value, skey) do
             value
-              |> Map.put(key, Map.get(value, skey))
-              |> Map.delete(skey)
+            |> Map.put(key, Map.get(value, skey))
+            |> Map.delete(skey)
           else
             value
           end
@@ -19,6 +21,6 @@ defmodule Validate.Rules.Atomize do
         end
       end)
 
-      success(value)
+    success(value)
   end
 end

--- a/lib/validate/rules/atomize.ex
+++ b/lib/validate/rules/atomize.ex
@@ -1,0 +1,24 @@
+defmodule Validate.Rules.Atomize do
+  @moduledoc false
+
+  import Validate.Validator
+
+  def validate(%{value: value, rules: rules}) do
+      value = Enum.reduce(rules[:map], value, fn {key, _}, value ->
+        if is_atom(key) do
+          skey = Atom.to_string(key)
+          if !Map.has_key?(value, key) && Map.has_key?(value, skey) do
+            value
+              |> Map.put(key, Map.get(value, skey))
+              |> Map.delete(skey)
+          else
+            value
+          end
+        else
+          value
+        end
+      end)
+
+      success(value)
+  end
+end

--- a/lib/validate/validator.ex
+++ b/lib/validate/validator.ex
@@ -10,7 +10,7 @@ defmodule Validate.Validator do
 
   defmodule Arg do
     @moduledoc false
-    defstruct value: nil, arg: nil, input: nil
+    defstruct value: nil, arg: nil, input: nil, rules: nil
   end
 
   @doc """

--- a/test/validate_test/rules/atomize_test.exs
+++ b/test/validate_test/rules/atomize_test.exs
@@ -1,0 +1,61 @@
+defmodule ValidateTest.Rules.AtomizeTest do
+  use ExUnit.Case
+
+  import Validate.Validator
+
+  test "it does not convert to atom" do
+    rules = [
+      type: :map,
+      map: %{
+        "key" => [type: :string]
+      }
+    ]
+
+    input = %{"key" => "value"}
+
+    assert Validate.validate(input, rules) == success(%{"key" => "value"})
+  end
+
+  test "it convert to atom" do
+    rules = [
+      type: :map,
+      atomize: true,
+      map: %{
+        :key => [type: :string]
+      }
+    ]
+
+    input = %{"key" => "value"}
+
+    assert Validate.validate(input, rules) == success(%{:key => "value"})
+  end
+
+  test "it converts only atom keys" do
+    rules = [
+      type: :map,
+      atomize: true,
+      map: %{
+        :key => [type: :string],
+        "non_atom" => [type: :string]
+      }
+    ]
+
+    input = %{"key" => "value", "non_atom" => "value2"}
+
+    assert Validate.validate(input, rules) == success(%{:key => "value", "non_atom" => "value2"})
+  end
+
+  test "it priorizes atom over string key" do
+    rules = [
+      type: :map,
+      atomize: true,
+      map: %{
+        :key => [type: :string]
+      }
+    ]
+
+    input = %{"key" => "string key value", :key => "atom key value"}
+
+    assert Validate.validate(input, rules) == success(%{:key => "atom key value"})
+  end
+end


### PR DESCRIPTION
Allow map to auto convert keys passed as strings to atoms.
```elixir
rules = [
  type: :map,
  atomize: true,
  map: %{
    :key => [type: :string]
  }
]

input = %{"key" => "value"}

assert Validate.validate(input, rules) == success(%{:key => "value"})
```

- Converts only atom keys defined in the rules
- No impact on the string keys defined in the rules
- When both atom and string is present in the input, priority is given to atom key.